### PR TITLE
Fix multi-target sync: unique constraint on source_asset_id

### DIFF
--- a/src/asset_sync.py
+++ b/src/asset_sync.py
@@ -52,16 +52,19 @@ async def get_unsynced_source_assets(
           AND NOT EXISTS (
             SELECT 1 FROM _face_sync_asset_map m
             WHERE m.source_asset_id = a.id
+              AND m.target_user_id = $4
           )
           AND NOT EXISTS (
             SELECT 1 FROM _face_sync_skipped s
             WHERE s.source_asset_id = a.id
+              AND s.target_user_id = $4
           )
         LIMIT $3
         """,
         job.source_user_id,
         job.source_path_prefix,
         limit,
+        job.target_user_id,
     )
 
 
@@ -147,17 +150,20 @@ async def find_duplicate_filenames(
     return duplicates
 
 
-async def record_skipped_duplicates(conn: asyncpg.Connection, source_asset_ids: set[UUID]) -> None:
+async def record_skipped_duplicates(
+    conn: asyncpg.Connection, source_asset_ids: set[UUID], target_user_id: UUID
+) -> None:
     """Batch-insert skip records for duplicate assets."""
     if not source_asset_ids:
         return
     await conn.execute(
         """
-        INSERT INTO _face_sync_skipped (source_asset_id, reason)
-        SELECT unnest($1::uuid[]), 'duplicate_filename'
-        ON CONFLICT (source_asset_id) DO NOTHING
+        INSERT INTO _face_sync_skipped (source_asset_id, target_user_id, reason)
+        SELECT unnest($1::uuid[]), $2, 'duplicate_filename'
+        ON CONFLICT (source_asset_id, target_user_id) DO NOTHING
         """,
         list(source_asset_ids),
+        target_user_id,
     )
 
 
@@ -187,13 +193,13 @@ async def sync_asset(conn: asyncpg.Connection, source: asyncpg.Record, job: Sync
     )
     if existing is not None:
         # Already synced but mapping was lost (crash recovery) — re-create mapping
-        # Use DO NOTHING (no conflict target) to handle unique violations on
-        # either source_asset_id or target_asset_id.
+        # Use conflict on the composite key (source_asset_id, target_user_id) since
+        # that's our unique constraint. Also catches target_asset_id conflicts.
         result = await conn.execute(
             """
             INSERT INTO _face_sync_asset_map (source_asset_id, target_asset_id, source_user_id, target_user_id, synced_at)
             VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT DO NOTHING
+            ON CONFLICT (source_asset_id, target_user_id) DO NOTHING
             """,
             source_id, existing, job.source_user_id, target_user_id, now,
         )
@@ -300,11 +306,12 @@ async def sync_asset(conn: asyncpg.Connection, source: asyncpg.Record, job: Sync
         remove_hardlinks(created_files)
         await conn.execute(
             """
-            INSERT INTO _face_sync_skipped (source_asset_id, reason)
-            VALUES ($1, 'duplicate_checksum')
-            ON CONFLICT (source_asset_id) DO NOTHING
+            INSERT INTO _face_sync_skipped (source_asset_id, target_user_id, reason)
+            VALUES ($1, $2, 'duplicate_checksum')
+            ON CONFLICT (source_asset_id, target_user_id) DO NOTHING
             """,
             source_id,
+            target_user_id,
         )
         logger.warning("Skipping asset %s: duplicate checksum for target user", source_id)
         return None

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 import sys
 
+import asyncpg
+
 from src.config import settings
 from src.db import close_pool, execute, fetch_one, init_pool, reset_pool
 from src.health import start_health_server, stop_health_server
@@ -12,16 +14,28 @@ from src.sync_engine import run_full_sync
 logger = logging.getLogger(__name__)
 
 
+SCHEMA_VERSION = 2  # Bump when tracking table schema changes
+
+
 async def ensure_tracking_tables() -> None:
-    """Create the sidecar's tracking tables if they don't exist."""
+    """Create the sidecar's tracking tables if they don't exist, and run migrations."""
+    # Version tracking table (created first so migrations can read it)
+    await execute("""
+        CREATE TABLE IF NOT EXISTS _face_sync_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+    """)
+
     await execute("""
         CREATE TABLE IF NOT EXISTS _face_sync_asset_map (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-            source_asset_id UUID NOT NULL UNIQUE,
+            source_asset_id UUID NOT NULL,
             target_asset_id UUID NOT NULL UNIQUE,
             source_user_id UUID NOT NULL,
             target_user_id UUID NOT NULL,
-            synced_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            synced_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE (source_asset_id, target_user_id)
         )
     """)
     await execute("""
@@ -36,12 +50,86 @@ async def ensure_tracking_tables() -> None:
     """)
     await execute("""
         CREATE TABLE IF NOT EXISTS _face_sync_skipped (
-            source_asset_id UUID PRIMARY KEY,
+            source_asset_id UUID NOT NULL,
+            target_user_id UUID NOT NULL,
             reason TEXT NOT NULL,
-            skipped_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            skipped_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (source_asset_id, target_user_id)
         )
     """)
-    logger.info("Tracking tables ready")
+
+    await _run_migrations()
+    logger.info("Tracking tables ready (schema version %d)", SCHEMA_VERSION)
+
+
+async def _run_migrations() -> None:
+    """Run pending schema migrations based on stored version."""
+    row = await fetch_one(
+        "SELECT value FROM _face_sync_meta WHERE key = 'schema_version'"
+    )
+    current = int(row["value"]) if row else 1
+
+    if current >= SCHEMA_VERSION:
+        return
+
+    if current < 2:
+        await _migrate_v2()
+
+    await execute(
+        """
+        INSERT INTO _face_sync_meta (key, value) VALUES ('schema_version', $1)
+        ON CONFLICT (key) DO UPDATE SET value = $1
+        """,
+        str(SCHEMA_VERSION),
+    )
+    logger.info("Migrated tracking tables from v%d to v%d", current, SCHEMA_VERSION)
+
+
+async def _migrate_v2() -> None:
+    """GH issue #1: allow syncing one source asset to multiple target users.
+
+    - _face_sync_asset_map: UNIQUE(source_asset_id) -> UNIQUE(source_asset_id, target_user_id)
+    - _face_sync_skipped: add target_user_id, change PK to composite
+    """
+    # Fix asset map unique constraint
+    await execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = '_face_sync_asset_map_source_asset_id_key'
+                  AND conrelid = '_face_sync_asset_map'::regclass
+            ) THEN
+                ALTER TABLE _face_sync_asset_map
+                    DROP CONSTRAINT _face_sync_asset_map_source_asset_id_key;
+                ALTER TABLE _face_sync_asset_map
+                    ADD CONSTRAINT _face_sync_asset_map_source_target_user_key
+                    UNIQUE (source_asset_id, target_user_id);
+            END IF;
+        END $$
+    """)
+
+    # Recreate skipped table with target_user_id (skip data is just an
+    # optimisation — losing it means a one-time re-check of skipped assets)
+    await execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = '_face_sync_skipped'
+                  AND column_name = 'target_user_id'
+            ) THEN
+                DROP TABLE _face_sync_skipped;
+                CREATE TABLE _face_sync_skipped (
+                    source_asset_id UUID NOT NULL,
+                    target_user_id UUID NOT NULL,
+                    reason TEXT NOT NULL,
+                    skipped_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (source_asset_id, target_user_id)
+                );
+            END IF;
+        END $$
+    """)
 
 
 async def validate_user_and_library_ids() -> None:

--- a/src/ml_sync.py
+++ b/src/ml_sync.py
@@ -145,8 +145,9 @@ async def sync_faces_incremental(conn: asyncpg.Connection) -> int:
         if count > 0:
             # Update the watermark so we don't re-check this asset next cycle
             await conn.execute(
-                "UPDATE _face_sync_asset_map SET synced_at = NOW() WHERE source_asset_id = $1",
+                "UPDATE _face_sync_asset_map SET synced_at = NOW() WHERE source_asset_id = $1 AND target_user_id = $2",
                 pair["source_asset_id"],
+                pair["target_user_id"],
             )
         total += count
 

--- a/src/sync_engine.py
+++ b/src/sync_engine.py
@@ -46,7 +46,7 @@ async def run_full_sync() -> dict:
                 # Duplicate detection: skip source assets already in target by filename + capture time
                 duplicates = await find_duplicate_filenames(conn, source_assets, job)
                 if duplicates:
-                    await record_skipped_duplicates(conn, duplicates)
+                    await record_skipped_duplicates(conn, duplicates, job.target_user_id)
                     stats["assets_skipped_duplicate"] += len(duplicates)
                     logger.warning(
                         "Job %s: skipping %d duplicate(s) by filename+date",


### PR DESCRIPTION
## Summary

Fixes #1 — `_face_sync_asset_map` had `UNIQUE(source_asset_id)` which prevented syncing one source library to multiple target users. Only the first job would sync; subsequent jobs found all source assets already mapped and synced 0 assets.

- Changed unique constraint to `UNIQUE(source_asset_id, target_user_id)` so each source asset can map to one target per user
- Added `target_user_id` to `_face_sync_skipped` table (skip reasons are target-specific)
- Scoped all tracking queries in `asset_sync.py` and `ml_sync.py` by `target_user_id`
- Added versioned migration system (`_face_sync_meta` table) so existing installs upgrade automatically on first run
- Fixed pre-existing missing `import asyncpg` in `main.py`

## Test plan

- [ ] Configure two sync jobs with same source_user_id but different target users
- [ ] Verify both jobs sync assets (not just the first)
- [ ] Verify migration runs correctly on an existing install (old schema → new)
- [ ] Verify fresh install creates correct schema directly